### PR TITLE
Set margins to zero for Graphviz output so generated PDFs are usable in documents

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -357,6 +357,7 @@ class CFGDotExporter(Exporter):
                     logging.info("Drawing CFG image to '%s'.", out_filename)
                     page.write(html)
             else:
+                pdG.set_margin(0)
                 pdG.write(out_filename, format=extension)
 
         # Otherwise, write a regular dot file using pydot


### PR DESCRIPTION
Currently, generating vector graphics (e.g. PDFs) using vandal produces images with margins too wide to be practical. This fix simply sets margins to 0 for non-HTML output types.