### PR TITLE
Added new opcodes from Constantinople

### DIFF
--- a/src/memtypes.py
+++ b/src/memtypes.py
@@ -391,6 +391,20 @@ class Variable(ssle, Location):
         """Return the b'th byte of v."""
         return (v >> ((cls.SIZE - b) * 8)) & 0xFF
 
+    @classmethod
+    def SHL(cls, b: int, v: int) -> int:
+        """Bitwise shift left."""
+        return v << b
+
+    @classmethod
+    def SHR(cls, b: int, v: int) -> int:
+        """Bitwise shift right."""
+        return v >> b
+
+    @classmethod
+    def SAR(cls, b: int, v: int) -> int:
+        """Arithmetic shift right."""
+        return cls.twos_comp(v) >> b
 
 class MetaVariable(Variable):
     """A Variable to stand in for Variables."""

--- a/src/opcodes.py
+++ b/src/opcodes.py
@@ -290,7 +290,7 @@ CALL = OpCode("CALL", 0xf1, 7, 1)
 CALLCODE = OpCode("CALLCODE", 0xf2, 7, 1)
 RETURN = OpCode("RETURN", 0xf3, 2, 0)
 DELEGATECALL = OpCode("DELEGATECALL", 0xf4, 6, 1)
-CREATE2 = OpCode("CREATE2", 4, 1)
+CREATE2 = OpCode("CREATE2", 0xfb, 4, 1)
 INVALID = OpCode("INVALID", 0xfe, 0, 0)
 SELFDESTRUCT = OpCode("SELFDESTRUCT", 0xff, 1, 0)
 

--- a/src/opcodes.py
+++ b/src/opcodes.py
@@ -91,7 +91,7 @@ class OpCode:
     def is_arithmetic(self) -> bool:
         """Predicate: opcode's result can be calculated from its inputs alone."""
         return (ADD.code <= self.code <= SIGNEXTEND.code) or \
-               (LT.code <= self.code <= BYTE.code)
+               (LT.code <= self.code <= SAR.code)
 
     def is_memory(self) -> bool:
         """Predicate: opcode operates on memory"""
@@ -166,6 +166,9 @@ OR = OpCode("OR", 0x17, 2, 1)
 XOR = OpCode("XOR", 0x18, 2, 1)
 NOT = OpCode("NOT", 0x19, 1, 1)
 BYTE = OpCode("BYTE", 0x1a, 2, 1)
+SHL = OpCode("SHL", 0x1b, 2, 1)
+SHR = OpCode("SHR", 0x1c, 2, 1)
+SAR = OpCode("SAR", 0x1d, 2, 1)
 
 SHA3 = OpCode("SHA3", 0x20, 2, 1)
 
@@ -183,6 +186,7 @@ CODECOPY = OpCode("CODECOPY", 0x39, 3, 0)
 GASPRICE = OpCode("GASPRICE", 0x3a, 0, 1)
 EXTCODESIZE = OpCode("EXTCODESIZE", 0x3b, 1, 1)
 EXTCODECOPY = OpCode("EXTCODECOPY", 0x3c, 4, 0)
+EXTCODEHASH = OpCode("EXTCODEHASH", 0x3f, 1, 1)
 
 # Block Information
 BLOCKHASH = OpCode("BLOCKHASH", 0x40, 1, 1)
@@ -286,6 +290,7 @@ CALL = OpCode("CALL", 0xf1, 7, 1)
 CALLCODE = OpCode("CALLCODE", 0xf2, 7, 1)
 RETURN = OpCode("RETURN", 0xf3, 2, 0)
 DELEGATECALL = OpCode("DELEGATECALL", 0xf4, 6, 1)
+CREATE2 = OpCode("CREATE2", 4, 1)
 INVALID = OpCode("INVALID", 0xfe, 0, 0)
 SELFDESTRUCT = OpCode("SELFDESTRUCT", 0xff, 1, 0)
 


### PR DESCRIPTION
Added opcodes from EIP 145, EIP 1014, and EIP 1052. 
EIP 145 adds bitwise shifting instructions.
EIP 1014 adds a CREATE2, a second way of creating contracts that results in a different address, but is otherwise the same as CREATE.
EIP 1052 returns a keccak256 hash of a contract's bytecode.